### PR TITLE
Add a toString method to all structures

### DIFF
--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -207,6 +207,14 @@ class Channel {
     static extractID(url) {
         return parseURL(url).channel;
     }
+
+    /**
+     * 
+     * @returns {this.title} The title of the channel
+     */
+    toString() {
+        return this.title
+    }
 }
 
 module.exports = Channel;

--- a/src/structures/Playlist.js
+++ b/src/structures/Playlist.js
@@ -175,6 +175,14 @@ class Playlist {
     static extractID(url) {
         return parseURL(url).playlist;
     }
+
+    /**
+     * 
+     * @returns {this.title} The title of the playlist
+     */
+    toString() {
+        return this.title
+    }
 }
 
 module.exports = Playlist;

--- a/src/structures/Video.js
+++ b/src/structures/Video.js
@@ -176,6 +176,14 @@ class Video {
     static extractID(url) {
         return parseURL(url).video;
     }
+
+    /**
+     * 
+     * @returns {this.title} The title of the video
+     */
+    toString() {
+        return this.title
+    }
 }
 
 module.exports = Video;


### PR DESCRIPTION
Allows users to use the object and it returns the name of the channel/video/playlist instead of [object Object]